### PR TITLE
Add configurable restart delay

### DIFF
--- a/src/main/java/com/projectg/geyserupdater/bungee/util/GeyserBungeeDownloader.java
+++ b/src/main/java/com/projectg/geyserupdater/bungee/util/GeyserBungeeDownloader.java
@@ -82,10 +82,11 @@ public class GeyserBungeeDownloader {
      * Attempt to restart the server
      */
     private static void restartServer() {
-        logger.warn("The server will be restarting in 10 seconds!");
+        long restartTime = plugin.getConfig().getLong("Auto-Restart-Timer");
+        logger.warn("The server will be restarting in %d seconds!".formatted(restartTime));
         for (ProxiedPlayer player : plugin.getProxy().getPlayers()) {
-            player.sendMessage(new TextComponent(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("Restart-Message-Players"))));
+            player.sendMessage(new TextComponent(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("Restart-Message-Players").formatted(restartTime))));
         }
-        plugin.getProxy().getScheduler().schedule(plugin, () -> plugin.getProxy().stop(), 10L, TimeUnit.SECONDS);
+        plugin.getProxy().getScheduler().schedule(plugin, () -> plugin.getProxy().stop(), restartTime, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/com/projectg/geyserupdater/spigot/util/GeyserSpigotDownloader.java
+++ b/src/main/java/com/projectg/geyserupdater/spigot/util/GeyserSpigotDownloader.java
@@ -97,9 +97,10 @@ public class GeyserSpigotDownloader {
      * Attempt to restart the server
      */
     private static void restartServer() {
-        logger.warn("The server will be restarting in 10 seconds!");
+        long restartTimer = plugin.getConfig().getLong("Auto-Restart-Timer");
+        logger.warn("The server will be restarting in %d seconds!".formatted(restartTimer));
         for (Player player : Bukkit.getOnlinePlayers()) {
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("Restart-Message-Players")));
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("Restart-Message-Players").formatted(restartTimer)));
         }
         // Attempt to restart the server 10 seconds after the message
         new BukkitRunnable() {
@@ -122,6 +123,6 @@ public class GeyserSpigotDownloader {
                     logger.error("Failed to restart the server!", e);
                 }
             }
-        }.runTaskLater(plugin, 200); // 200 ticks is around 10 seconds (at 20 TPS)
+        }.runTaskLater(plugin, restartTimer * 20); // 200 ticks is around 10 seconds (at 20 TPS)
     }
 }

--- a/src/main/java/com/projectg/geyserupdater/velocity/util/GeyserVelocityDownloader.java
+++ b/src/main/java/com/projectg/geyserupdater/velocity/util/GeyserVelocityDownloader.java
@@ -86,13 +86,14 @@ public class GeyserVelocityDownloader {
      * Attempt to restart the server
      */
     private static void restartServer() {
-        logger.warn("The server will be restarting in 10 seconds!");
+        long restartTime = plugin.getConfig().getLong("Auto-Restart-Timer");
+        logger.warn("The server will be restarting in %d seconds!".formatted(restartTime));
         for (Player player : server.getAllPlayers()) {
-            player.sendMessage(Component.text(plugin.getConfig().getString("Restart-Message-Players")));
+            player.sendMessage(Component.text(plugin.getConfig().getString("Restart-Message-Players").formatted(restartTime)));
         }
         server.getScheduler()
                 .buildTask(plugin, server::shutdown)
-                .delay(10L, TimeUnit.SECONDS)
+                .delay(restartTime, TimeUnit.SECONDS)
                 .schedule();
     }
 }

--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -9,15 +9,16 @@ Auto-Update-Geyser=false
 # The interval in hours between each auto update check.
 Auto-Update-Interval=24
 
-# If enabled, GeyserUpdater will attempt to restart the server 10 seconds after a new version of Geyser has been successfully downloaded.
+# If enabled, GeyserUpdater will attempt to restart the server a number of seconds in Auto-Restart-Timer (default 10) after a new version of Geyser has been successfully downloaded.
 # If you aren't using a hosting provider or a server wrapper, you will need a restart script.
 Auto-Restart-Server=false
+Auto-Restart-Timer=10
 # When enabled, GeyserUpdater will automatically generate a restart script for you. If you are using CraftBukkit or a proxy
 # you will need to use the generated script to start your server! If you are using a hosting provider or a server wrapper you probably don't need this.
 Auto-Script-Generating=false
 
-# Configure the message that is sent to all online players warning them that the server will be restarting in 10 seconds.
-Restart-Message-Players='&2This server will be restarting in 10 seconds!'
+# Configure the message that is sent to all online players warning them that the server will be restarting in some seconds. Use '%d' as the seconds placeholder.
+Restart-Message-Players='&2This server will be restarting in %d seconds!'
 
 # Enable debug logging
 Enable-Debug=false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,15 +9,17 @@ Auto-Update-Geyser: false
 # The interval in hours between each auto update check.
 Auto-Update-Interval: 24
 
-# If enabled, GeyserUpdater will attempt to restart the server 10 seconds after a new version of Geyser has been successfully downloaded.
+# If enabled, GeyserUpdater will attempt to restart the server a number of seconds in Auto-Restart-Timer (default 10) after a new version of Geyser has been successfully downloaded.
 # If you aren't using a hosting provider or a server wrapper, you will need a restart script.
 Auto-Restart-Server: false
+Auto-Restart-Timer: 10
+
 # When enabled, GeyserUpdater will automatically generate a restart script for you. If you are using CraftBukkit or a proxy
 # you will need to use the generated script to start your server! If you are using a hosting provider or a server wrapper you probably don't need this.
 Auto-Script-Generating: false
 
-# Configure the message that is sent to all online players warning them that the server will be restarting in 10 seconds.
-Restart-Message-Players: '&2This server will be restarting in 10 seconds!'
+# Configure the message that is sent to all online players warning them that the server will be restarting in some seconds. Use '%d' as the seconds placeholder.
+Restart-Message-Players: '&2This server will be restarting in %d seconds!'
 
 # Enable debug logging
 Enable-Debug: false


### PR DESCRIPTION
Added a configurable restart delay to the config, with the default being the old 10 seconds. Messages have been updated using Java string formatting.